### PR TITLE
Escaping of command output

### DIFF
--- a/sensu-shell-helper
+++ b/sensu-shell-helper
@@ -113,8 +113,9 @@ if ! [[ "$CHECK_NAME" =~ ^[A-Za-z0-9_.-]+$ ]]; then
 fi
 
 # Actually execute the command and suck in the result
+# Also, escape backslash and double quotes in command output, ready for insertion into JSON
 set -o pipefail
-CHECK_RESULT=$( $* 2>&1 $LOG_ARG | tail -n $LINE_COUNT )
+CHECK_RESULT=$( $* 2>&1 $LOG_ARG | tail -n $LINE_COUNT | sed 's@\([\"]\)@\\\\\1@g' )
 RET_CODE=$?
 
 # Normally scripts do not return nagios compliant return codes, so we return 2

--- a/sensu_helper_tests.sh
+++ b/sensu_helper_tests.sh
@@ -33,6 +33,23 @@ shouldbe='{
   [[ "$(./sensu-shell-helper -d /bin/echo test 2>&1)" == "$shouldbe" ]]
 )
 
+function test_with_output_escape_double_quotes() (
+shouldbe='{
+"name": "_bin_echo_test__double_quotes_",
+"output": "test \"double quotes\"",
+"status": 0
+}'
+  [[ "$(./sensu-shell-helper -d /bin/echo 'test "double quotes"' 2>&1)" == "$shouldbe" ]]
+)
+
+function test_with_output_escape_backslash() (
+shouldbe='{
+"name": "_bin_echo_test___backslash",
+"output": "test \\ backslash",
+"status": 0
+}'
+  [[ "$(./sensu-shell-helper -d /bin/echo 'test \ backslash' 2>&1)" == "$shouldbe" ]]
+)
 
 function test_with_hyphens() (
 shouldbe='{


### PR DESCRIPTION
Hi,

I've fixed a small problem with the check name sanitizing, and added basic JSON escaping of the command output. (Double quotes in my command's output was causing invalid JSON to be returned.)

I've done this in a very simple way, but a more comprehensive method is given here: http://stackoverflow.com/a/13466143/1011363

However, I didn't want to add a dependency on python to the script.

Regards,
Mike
