### PR TITLE
Updated to condense output to one line, turn newlines in command output into spaces with the exception of the last character.

### DIFF
--- a/sensu-shell-helper
+++ b/sensu-shell-helper
@@ -113,9 +113,9 @@ if ! [[ "$CHECK_NAME" =~ ^[A-Za-z0-9_.-]+$ ]]; then
 fi
 
 # Actually execute the command and suck in the result
-# Also, escape backslash and double quotes in command output, ready for insertion into JSON
+# Also, escape backslash and double quotes in command output, ready for insertion into JSON and turn all newlines into spaces with the exception of the last character.
 set -o pipefail
-CHECK_RESULT=$( $* 2>&1 $LOG_ARG | tail -n $LINE_COUNT | sed 's@\([\"]\)@\\\\\1@g'|while read -d $'\n'; do echo -n "${REPLY} "; done|sed 's/\ $//g' )
+CHECK_RESULT=$( $* 2>&1 $LOG_ARG | tail -n $LINE_COUNT |sed 's@\([\"]\)@\\\\\1@g'|while read -d $'\n'; do echo -en "${REPLY} "|sed 's@\([\"]\)@\\\\\1@g;s@\\\\\\"@\"@g'; done|sed 's/\ $//g' )
 RET_CODE=$?
 
 # Normally scripts do not return nagios compliant return codes, so we return 2

--- a/sensu_helper_tests.sh
+++ b/sensu_helper_tests.sh
@@ -7,11 +7,7 @@ function test_bad_option() (
 )
 
 function test_with_default_args_in_a_simple_case() (
-EXPECTED='{
-"name": "_bin_true",
-"output": "",
-"status": 0
-}'
+EXPECTED='{"name": "_bin_true","output": "","status": 0}'
 ACTUAL=$(./sensu-shell-helper -d /bin/true 2>&1)
 if ! [[ "$ACTUAL" == "$EXPECTED" ]]; then
   echo "Actual output:"
@@ -23,11 +19,7 @@ fi
 )
 
 function test_failing_output() (
-EXPECTED='{
-"name": "_bin_false",
-"output": "",
-"status": 2
-}'
+EXPECTED='{"name": "_bin_false","output": "","status": 2}'
 ACTUAL=$(./sensu-shell-helper -d /bin/false 2>&1)
 if ! [[ "$ACTUAL" == "$EXPECTED" ]]; then
   echo "Actual output:"
@@ -39,11 +31,7 @@ fi
 )
 
 function test_with_output() (
-EXPECTED='{
-"name": "_bin_echo_test",
-"output": "test",
-"status": 0
-}'
+EXPECTED='{"name": "_bin_echo_test","output": "test","status": 0}'
 ACTUAL=$(./sensu-shell-helper -d /bin/echo test 2>&1)
 if ! [[ "$ACTUAL" == "$EXPECTED" ]]; then
   echo "Actual output:"
@@ -55,11 +43,7 @@ fi
 )
 
 function test_with_output_escape_double_quotes() (
-EXPECTED='{
-"name": "_bin_echo_test__double_quotes_",
-"output": "test \"double quotes\"",
-"status": 0
-}'
+EXPECTED='{"name": "_bin_echo_test__double_quotes_","output": "test \"double quotes\"","status": 0}'
 ACTUAL=$(./sensu-shell-helper -d /bin/echo 'test "double quotes"' 2>&1)
 if ! [[ "$ACTUAL" == "$EXPECTED" ]]; then
   echo "Actual output:"
@@ -71,11 +55,7 @@ fi
 )
 
 function test_with_output_escape_backslash() (
-EXPECTED='{
-"name": "_bin_echo_test___backslash",
-"output": "test \\ backslash",
-"status": 0
-}'
+EXPECTED='{"name": "_bin_echo_test___backslash","output": "test \\ backslash","status": 0}'
 ACTUAL=$(./sensu-shell-helper -d /bin/echo 'test \ backslash' 2>&1)
 if ! [[ "$ACTUAL" == "$EXPECTED" ]]; then
   echo "Actual output:"
@@ -87,11 +67,7 @@ fi
 )
 
 function test_with_hyphens() (
-EXPECTED='{
-"name": "_bin_echo_test",
-"output": "test",
-"status": 0
-}'
+EXPECTED='{"name": "_bin_echo_test","output": "test","status": 0}'
 ACTUAL=$(./sensu-shell-helper -d -- /bin/echo test 2>&1)
 if ! [[ "$ACTUAL" == "$EXPECTED" ]]; then
   echo "Actual output:"
@@ -103,12 +79,7 @@ fi
 )
 
 function test_with_handlers() (
-EXPECTED='{
-"name": "_bin_echo_test",
-"output": "test",
-"handlers": ["email", "pagerduty"],
-"status": 0
-}'
+EXPECTED='{"name": "_bin_echo_test","output": "test","handlers": ["email", "pagerduty"],"status": 0}'
 ACTUAL=`./sensu-shell-helper -d -H '["email", "pagerduty"]' -- /bin/echo test 2>&1`
 if ! [[ "$ACTUAL" == "$EXPECTED" ]]; then
   echo "Actual output:"
@@ -120,11 +91,7 @@ fi
 )
 
 function test_alternate_name() (
-EXPECTED='{
-"name": "Name_Override",
-"output": "",
-"status": 0
-}'
+EXPECTED='{"name": "Name_Override","output": "","status": 0}'
 ACTUAL=`./sensu-shell-helper -d -n "Name Override"  /bin/true 2>&1`
 if ! [[ "$ACTUAL" == "$EXPECTED" ]]; then
   echo "Actual output:"
@@ -136,12 +103,7 @@ fi
 )
 
 function test_with_extra_JSON() (
-EXPECTED='{
-"name": "_bin_echo_test",
-"output": "test",
-"metric": false
-"status": 0
-}'
+EXPECTED='{"name": "_bin_echo_test","output": "test","metric": false"status": 0}'
 ACTUAL=`./sensu-shell-helper -d -j '"metric": false' -- /bin/echo test 2>&1`
 if ! [[ "$ACTUAL" == "$EXPECTED" ]]; then
   echo "Actual output:"
@@ -153,13 +115,7 @@ fi
 )
 
 function test_multilines() (
-EXPECTED='{
-"name": "_usr_bin_seq_1_5",
-"output": "3
-4
-5",
-"status": 0
-}'
+EXPECTED='{"name": "_usr_bin_seq_1_5","output": "3 4 5","status": 0}'
 ACTUAL=`./sensu-shell-helper -d /usr/bin/seq 1 5 2>&1`
 if ! [[ "$ACTUAL" == "$EXPECTED" ]]; then
   echo "Actual output:"
@@ -171,15 +127,7 @@ fi
 )
 
 function test_10_multilines() (
-EXPECTED='{
-"name": "_usr_bin_seq_1_100",
-"output": "96
-97
-98
-99
-100",
-"status": 0
-}'
+EXPECTED='{"name": "_usr_bin_seq_1_100","output": "96 97 98 99 100","status": 0}'
 ACTUAL=`./sensu-shell-helper -d -c 5 /usr/bin/seq 1 100 2>&1`
 if ! [[ "$ACTUAL" == "$EXPECTED" ]]; then
   echo "Actual output:"
@@ -191,11 +139,7 @@ fi
 )
 
 function test_non_nagios_compliant() (
-EXPECTED='{
-"name": "exit_42",
-"output": "",
-"status": 2
-}'
+EXPECTED='{"name": "exit_42","output": "","status": 2}'
 ACTUAL=`./sensu-shell-helper -d -- exit 42 2>&1`
 if ! [[ "$ACTUAL" == "$EXPECTED" ]]; then
   echo "Actual output:"
@@ -207,11 +151,7 @@ fi
 )
 
 function test_nagios_compliant() (
-EXPECTED='{
-"name": "exit_42",
-"output": "",
-"status": 42
-}'
+EXPECTED='{"name": "exit_42","output": "","status": 42}'
 ACTUAL=`./sensu-shell-helper -N -d -- exit 42 2>&1`
 if ! [[ "$ACTUAL" == "$EXPECTED" ]]; then
   echo "Actual output:"


### PR DESCRIPTION
Updated to condense output to one line, turn newlines in command output into spaces with the exception of the last character. Tests updated to reflect the new expected output. Had to mess with the sed strings a little to get backslashes and double quotes escaped properly after condensing to a newline. 
